### PR TITLE
对返回数据中的范型情况进行处理

### DIFF
--- a/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
+++ b/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
@@ -59,6 +59,16 @@ public class ParamPsiUtils {
 
             childClass = PsiUtil.resolveClassInClassTypeOnly(iterableType);
 
+            if (genericMap != null) {
+                PsiType psiType = genericMap.get(iterableType.getPresentableText());
+                if (FieldTypeConstant.FIELD_TYPE.containsKey(psiType.getPresentableText())) {
+                    body.setType(psiType.getPresentableText());
+                    return;
+                }
+                childClass = PsiUtil.resolveClassInClassTypeOnly(psiType);
+            }
+
+
         } else if (InheritanceUtil.isInheritor(type, CommonClassNames.JAVA_UTIL_MAP)) {
             // HashMap or Map
             PsiType matValueType = PsiUtil.substituteTypeParameter(type, CommonClassNames.JAVA_UTIL_MAP, 1, false);

--- a/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
+++ b/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
@@ -46,10 +46,12 @@ public class ParamPsiUtils {
         // 字段如果是类, 则会继续对当前 body 进行设置 child
 
         PsiClass childClass;
+        PsiClassType childClassType = null;
 
         if (InheritanceUtil.isInheritor(type, CommonClassNames.JAVA_UTIL_COLLECTION)) {
             // List Set or HashSet
             PsiType iterableType = PsiUtil.extractIterableTypeParameter(type, false);
+            childClassType = (PsiClassType) iterableType;
 
             if (iterableType instanceof PsiPrimitiveType
                     || iterableType == null
@@ -61,6 +63,7 @@ public class ParamPsiUtils {
 
             if (genericMap != null) {
                 PsiType psiType = genericMap.get(iterableType.getPresentableText());
+                childClassType = (PsiClassType) psiType;
                 if (FieldTypeConstant.FIELD_TYPE.containsKey(psiType.getPresentableText())) {
                     body.setType(psiType.getPresentableText());
                     return;
@@ -72,6 +75,7 @@ public class ParamPsiUtils {
         } else if (InheritanceUtil.isInheritor(type, CommonClassNames.JAVA_UTIL_MAP)) {
             // HashMap or Map
             PsiType matValueType = PsiUtil.substituteTypeParameter(type, CommonClassNames.JAVA_UTIL_MAP, 1, false);
+            childClassType = (PsiClassType) matValueType;
 
             if (matValueType instanceof PsiPrimitiveType
                     || matValueType == null
@@ -86,6 +90,7 @@ public class ParamPsiUtils {
                 return;
             }
             PsiType psiType = genericMap.get(type.getPresentableText());
+            childClassType = (PsiClassType) psiType;
 
             if (FieldTypeConstant.FIELD_TYPE.containsKey(psiType.getPresentableText())) {
                 body.setType(psiType.getPresentableText());
@@ -108,9 +113,11 @@ public class ParamPsiUtils {
             body.setQualifiedNameForClassType(qualifiedName);
         }
 
+        Map<String, PsiType> map = CustomPsiUtils.getGenericMap(childClass, childClassType);
+
         for (PsiField psiField : childClass.getAllFields()) {
             if (!DocViewUtils.isExcludeField(psiField)) {
-                buildBodyParam(psiField, null, body);
+                buildBodyParam(psiField, map, body);
             }
         }
     }

--- a/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
+++ b/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
@@ -90,6 +90,10 @@ public class ParamPsiUtils {
                 return;
             }
             PsiType psiType = genericMap.get(type.getPresentableText());
+           // todo-zhangdd: 2021/8/14 如果范型是个集合 ,当前方法最好对 各个类型的处理做个单一对应的处理方法来实现
+            if (InheritanceUtil.isInheritor(psiType, CommonClassNames.JAVA_UTIL_COLLECTION)) {
+
+            }
             childClassType = (PsiClassType) psiType;
 
             if (FieldTypeConstant.FIELD_TYPE.containsKey(psiType.getPresentableText())) {


### PR DESCRIPTION
这里是两个包装类
#### 分页包装类
```
public class PageResult<T> {

    private Integer pageIndex;

    private Integer pageSize;

    List<T> data;
}
```
#### 返回结果最外层包装类

```
public class ResultBean<T> {
    /*是否成功*/
    private Boolean success;
    /*编码*/
    private String code;
    /*信息*/
    private String msg;
    /*请求的唯一主键*/
    private String requestId;
    /*数据体*/
    private T  data;
}
```

### 下面是几个场景

```
/**
     * 人员列表-分页
     *
     * @return
     */
    @GetMapping("/api/pagePerson1")
    public PageResult<Person> pagePerson() {
        return null;
    }


    /**
     * 人员详情 - 带包装结构
     *
     * @return
     */
    @GetMapping("/personDetail")
    public ResultBean<Person> personDetail() {
        return null;
    }

    /**
     * 人员详情1
     *
     * @return
     */
    @GetMapping("/personDetail1")
    public ResultBean<PageResult<Person>> personDetail1() {
        return null;
    }

    /**
     * 人员详情2
     *
     * @return
     */
    @GetMapping("/personDetail2")
    public ResultBean<List<Person>> personDetail2() {
        return null;
    }
```

----

其中第四个测试场景 `人员详情2`  当范型是集合是 在代码里列了一个todo。ParamPsiUtils#buildBodyParam 该方法的实现，可以稍微调整下。进行实现支持。