### PR TITLE
fix: 在仅配置showdoc文档上传，且配置完整时，提示"请添加 ShowDoc 相关配置"，

### DIFF
--- a/src/main/java/com/liuzhihang/doc/view/action/ShowDocUploadAction.java
+++ b/src/main/java/com/liuzhihang/doc/view/action/ShowDocUploadAction.java
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import com.liuzhihang.doc.view.DocViewBundle;
 import com.liuzhihang.doc.view.config.Settings;
+import com.liuzhihang.doc.view.config.ShowDocSettings;
 import com.liuzhihang.doc.view.config.ShowDocSettingsConfigurable;
 import com.liuzhihang.doc.view.config.YApiSettings;
 import com.liuzhihang.doc.view.dto.DocView;
@@ -70,11 +71,11 @@ public class ShowDocUploadAction extends AnAction {
             return;
         }
 
-        YApiSettings apiSettings = YApiSettings.getInstance(project);
+        ShowDocSettings apiSettings = ShowDocSettings.getInstance(project);
 
         if (StringUtils.isBlank(apiSettings.getUrl())
-                || apiSettings.getProjectId() == null
-                || StringUtils.isBlank(apiSettings.getToken())) {
+                || StringUtils.isBlank(apiSettings.getApiKey())
+                || StringUtils.isBlank(apiSettings.getApiToken())) {
             DocViewNotification.notifyError(project, DocViewBundle.message("notify.showdoc.info.settings"));
             ShowSettingsUtil.getInstance().showSettingsDialog(e.getProject(), ShowDocSettingsConfigurable.class);
             return;


### PR DESCRIPTION
reason: com.liuzhihang.doc.view.action.ShowDocUploadAction第74行获取配置时获取的时Yapi的配置

![image](https://user-images.githubusercontent.com/43911138/132656395-d81d804c-e5c2-4980-887f-dd0378193e2a.png)
