### PR TITLE
处理 新接口upload时“"errmsg":"服务器出错..."” 以及 markdown预览模式element元素展示问题

### DIFF
--- a/src/main/java/com/liuzhihang/doc/view/service/impl/YApiServiceImpl.java
+++ b/src/main/java/com/liuzhihang/doc/view/service/impl/YApiServiceImpl.java
@@ -95,7 +95,7 @@ public class YApiServiceImpl implements DocViewUploadService {
                 save.setPath(docView.getPath());
             }
             // 枚举: raw,form,json
-            save.setReqBodyType(docView.getContentType().toString());
+            save.setReqBodyType(docView.getContentType().toString().toLowerCase());
             save.setReqBodyForm(new ArrayList<>());
             save.setReqParams(new ArrayList<>());
             save.setReqHeaders(buildReqHeaders(docView.getHeaderList()));
@@ -124,9 +124,6 @@ public class YApiServiceImpl implements DocViewUploadService {
 
     /**
      * 构造描述信息
-     *
-     * @param docView
-     * @return
      */
     @NotNull
     private String buildDesc(DocView docView) {
@@ -156,9 +153,6 @@ public class YApiServiceImpl implements DocViewUploadService {
      * properties: 字段列表
      * <p>
      * items: 数组类型时内部元素
-     *
-     * @param bodyList
-     * @return
      */
     private String buildJsonSchema(List<Body> bodyList) {
 


### PR DESCRIPTION
1. 在1.3.0版本进行新接口上传yapi操作时，提交报文内容中 "req_body_type"的值为"FORM"，实际应该为小写"form"。该问题导致新的接口上传失败，旧的接口不能更新
2. 在预览 markdown 文档的渲染阶段移除element元素