### PR TITLE
Revert "判断递归结束的时候，不能用类型是否相等来判断，不然会出现list嵌套，而子list的element不进行递归的bug"

### DIFF
--- a/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
+++ b/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
@@ -59,7 +59,7 @@ public class ParamPsiUtils {
         // 判断 childClass 是否已经在根节点到当前节点的链表上存在, 存在的话则不继续递归
         String qualifiedName = fieldClass.getQualifiedName();
 
-        if (StringUtils.isBlank(qualifiedName)) {
+        if (StringUtils.isBlank(qualifiedName) || checkLinkedListHasTypeClass(body, qualifiedName)) {
             return;
         }
 


### PR DESCRIPTION
Reverts liuzhihang/doc-view#63