### PR TITLE
当泛型是基本类型或包装类型时不再递归

### DIFF
--- a/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
+++ b/src/main/java/com/liuzhihang/doc/view/utils/ParamPsiUtils.java
@@ -125,6 +125,9 @@ public class ParamPsiUtils {
             childClass = fieldClass;
         }
 
+        if (type instanceof PsiPrimitiveType || FieldTypeConstant.FIELD_TYPE.containsKey(type.getPresentableText())) {
+            return;
+        }
         for (PsiField psiField : childClass.getAllFields()) {
             if (!DocViewUtils.isExcludeField(psiField)) {
                 buildBodyParam(psiField, fieldGenericsMap, parentBody);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43911138/184332287-4a2077f4-fa79-40ec-9661-b6171d5d2962.png)
当泛型是基本类型或者包装类型时候，不应该再进行递归