### PR TITLE
修复模板设置窗口的模态类型

### DIFF
--- a/src/main/java/com/liuzhihang/doc/view/ui/SettingsForm.java
+++ b/src/main/java/com/liuzhihang/doc/view/ui/SettingsForm.java
@@ -80,7 +80,7 @@ public class SettingsForm {
         supportLinkLabel.setBorder(JBUI.Borders.emptyTop(20));
         supportLinkLabel.setIcon(AllIcons.Actions.Find);
 
-        supportLinkLabel.setListener((source, data) -> new SupportForm().show(), null);
+        supportLinkLabel.setListener((source, data) -> new SupportForm(project).show(), null);
 
         initTitleBorder();
     }

--- a/src/main/java/com/liuzhihang/doc/view/ui/SupportForm.java
+++ b/src/main/java/com/liuzhihang/doc/view/ui/SupportForm.java
@@ -1,10 +1,12 @@
 package com.liuzhihang.doc.view.ui;
 
 import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.util.ui.JBUI;
 import com.liuzhihang.doc.view.DocViewBundle;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -21,8 +23,8 @@ public class SupportForm extends DialogWrapper {
     private LinkLabel<String> discussionsLinkLabel;
     private LinkLabel<String> websiteLinkLabel;
 
-    public SupportForm() {
-        super(null, true, DialogWrapper.IdeModalityType.PROJECT);
+    public SupportForm(@NotNull Project project) {
+        super(project, true);
 
         init();
 

--- a/src/main/java/com/liuzhihang/doc/view/ui/TemplateSettingForm.java
+++ b/src/main/java/com/liuzhihang/doc/view/ui/TemplateSettingForm.java
@@ -40,7 +40,7 @@ public class TemplateSettingForm extends DialogWrapper {
     private final Project project;
 
     public TemplateSettingForm(Project project) {
-        super(project, true, DialogWrapper.IdeModalityType.PROJECT);
+        super(project, true);
         this.project = project;
 
         init();


### PR DESCRIPTION
此更改将模板设置窗口的模态类型更改为与SupportForm和SettingsForm中的模态类型保持一致。之前，TemplateSettingForm中使用了不必要的DialogWrapper.IdeModalityType.PROJECT，这与其他表单不一致。此更新确保所有表单在显示时具有相同的模态行为。