### PR TITLE
修复模板设置窗口的模态类型

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## [Unreleased]
 
-## 1.3.9
+## 1.3.10
 
 ### Added
 
-- 实体类编辑功能
-- 复制实体类为 JSON
+- ParamPsiUtils.buildBodyParam 处理自身引用的VO的时候堆栈溢出
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.caching=true
 # ????
 pluginGroup=com.liuzhihang.toolkit
 pluginName=Doc View
-pluginVersion=1.3.9
+pluginVersion=1.3.10
 pluginSinceBuild=241
 pluginUntilBuild=
 pluginDescription=parts/description.html


### PR DESCRIPTION
此更改将模板设置窗口的模态类型更改为与SupportForm和SettingsForm中的模态类型保持一致。之前，TemplateSettingForm中使用了不必要的DialogWrapper.IdeModalityType.PROJECT，这与其他表单不一致。此更新确保所有表单在显示时具有相同的模态行为。